### PR TITLE
Adding factory method & overrides for nConf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ To get started with neff you'll want to make sure you have setup nconf to contai
     "feature2": false
 }
 ```
+#### Argument-Based Config
+
+If you'd instead like to pass the features as parameters you can call the factory method to merge the arguments passed to the method with any (optional) nconf configuration you utilize in your project.
+
+```
+app.use(neff.factory({
+    "feature1": true,
+    "feature2": false
+}));
+```
 
 #### Express Helpers
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var config = require("nconf");
+var config = require("nconf"),
+	_ = require("lodash"),
+	features = {};
 
 /**
  * A connect middleware to limit access to routes based on flags.
@@ -60,7 +62,16 @@ function getEnabledFeatures() {
  * @Note this needs to be here, because nconf is not populated immediately
  */
 function getFeatures() {
-	return config.get("features") || {};
+	features = _.assign({}, config.get('features'), features);
+	return features;
+}
+
+/**
+ * Pass in an optional config to replace nconf, returns the middleware
+ */
+function factory(options) {
+	features = options || {};
+	return helpers;
 }
 
 /**
@@ -69,6 +80,7 @@ function getFeatures() {
 module.exports = {
 	isEnabled: isEnabled,
 	helpers: helpers,
-	limit: limit
+	limit: limit,
+	factory: factory
 };
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "license": "Apache 2.0",
   "dependencies": {
+    "lodash": "^3.3.1",
     "nconf": "~0.6.9"
   }
 }

--- a/test.js
+++ b/test.js
@@ -20,3 +20,15 @@ neff.helpers(req, res, function() {
 	assert.ok(res.locals['feature-featureA'], "feature a should exist in locals");
 	assert.ok(!res.locals['feature-featureB'], "feature b should not exist in locals");
 });
+
+// test the factory
+var factory = neff.factory({
+	"featureA": false,
+	"featureB": true
+});
+res = {locals:{}};
+factory(req, res, function() {
+	assert.equal(res.locals.featureClasses, "feature-featureB", "we should have a correct CSS string");
+	assert.ok(res.locals['feature-featureB'], "feature b should exist in locals");
+	assert.ok(!res.locals['feature-featureA'], "feature a should not exist in locals");
+});


### PR DESCRIPTION
This makes nconf usage optional by the parent. Merges the arguments passed to the factory with the nconf object to maintain backward compatibility.