### PR TITLE
Removing all dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,21 @@ if (moreUsers) {
 }
 ```
 
-### Server Side Usage
+
+#### Argument-Based Config
+
+To get started with neff you'll want to make sure you call neff, passing it an an object with feature names and either `true` or `false` values. 
+
+```
+app.use(neff({
+    "feature1": true,
+    "feature2": false
+}));
+```
 
 #### NConf-Based Config
 
-To get started with neff you'll want to make sure you have setup nconf to contain a `features` setting, which is an object with feature names and either `true` or `false` values. I'm currently doing this using a JSON file and my config looks like this:
+If you'd like to utilize NConf for this, you can reference an NConf JSON file and my config looks like this:
 
 ```json
 "features": {
@@ -21,12 +31,10 @@ To get started with neff you'll want to make sure you have setup nconf to contai
 }
 ```
 
-#### Express Helpers
-
-Neff provides a middleware to add feature flag information to express views. Its usage is:
+Then pass the config object for the features to neff:
 
 ```
-app.use(neff.helpers);
+app.use(neff(nconf.get('features')));
 ```
 
 The first thing it allows you to do is access feature flags directly in your template such as (dust syntax):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neff",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "nconf & express based features flags",
   "main": "index.js",
   "scripts": {
@@ -14,6 +14,6 @@
   },
   "license": "Apache 2.0",
   "dependencies": {
-    "nconf": "~0.6.9"
+    "lodash": "^3.3.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,22 +1,21 @@
 var neff = require("./");
-var config = require("nconf");
 var assert = require("assert");
-
-config.use("memory");
-config.set("features", {
-	featureA: true,
-	featureB: false
-});
-
-// test the basic stuff
-assert.ok(neff.isEnabled("featureA"), "feature a should be enabled");
-assert.ok(!neff.isEnabled("featureB"), "feature b should not be enbled");
 
 // test the helpers
 var req = {};
 var res = {locals:{}};
-neff.helpers(req, res, function() {
-	assert.equal(res.locals.featureClasses, "feature-featureA", "we should have a correct CSS string");
-	assert.ok(res.locals['feature-featureA'], "feature a should exist in locals");
-	assert.ok(!res.locals['feature-featureB'], "feature b should not exist in locals");
+
+// test the factory
+var middleware = neff({
+	"featureA": false,
+	"featureB": true
 });
+middleware(req, res, function() {
+	assert.equal(res.locals.featureClasses, "feature-featureB", "we should have a correct CSS string");
+	assert.ok(res.locals['feature-featureB'], "feature b should exist in locals");
+	assert.ok(!res.locals['feature-featureA'], "feature a should not exist in locals");
+});
+
+// test the basic stuff
+assert.ok(neff.isEnabled("featureB"), "feature a should be enabled");
+assert.ok(!neff.isEnabled("featureA"), "feature b should not be enbled");


### PR DESCRIPTION
This gets rid of the usage of nconf all together. No backward compatibility with previous versions of neff.