### PR TITLE
Fixing lodash prototype pollution vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var _ = require("lodash");
 var features = {};
 
 /**
@@ -59,7 +58,7 @@ function getEnabledFeatures() {
  * Pass in a features object, returns the middleware
  */
 function neff(options) {
-	features = _.extend(features, options);
+	features = Object.assign(features, options);
 	return helpers;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neff",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "nconf & express based features flags",
   "main": "index.js",
   "browser": "cjs.js",
@@ -13,8 +13,5 @@
     "type": "git",
     "url": "http://github.com/xjamundx/neff.git"
   },
-  "license": "Apache 2.0",
-  "dependencies": {
-    "lodash": "^3.3.1"
-  }
+  "license": "Apache 2.0"
 }


### PR DESCRIPTION
We need to upgrade this lodash version to 4.17.12 or higher because it has been identified as a high severity vulnerability by npm audit https://www.npmjs.com/advisories/1065